### PR TITLE
Separate `cluster_name` and `name` variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # terraform-aws-kops-chart-repo [![Build Status](https://travis-ci.org/cloudposse/terraform-aws-kops-chart-repo.svg?branch=master)](https://travis-ci.org/cloudposse/terraform-aws-kops-chart-repo)
 
-Terraform module to provision an S3 bucket for [Helm](https://helm.sh/) chart repository, and an IAM role and policy with permissions for k8s nodes to access the bucket.
+Terraform module to provision an S3 bucket for [Helm](https://helm.sh/) chart repository, and an IAM role and policy with permissions for Kops nodes to access the bucket.
 
 The module uses [terraform-aws-kops-metadata](https://github.com/cloudposse/terraform-aws-kops-metadata) to lookup resources within a Kops cluster for easier integration with Terraform.
 
@@ -12,11 +12,12 @@ module "kops_chart_repo" {
   source       = "git::https://github.com/cloudposse/terraform-aws-kops-chart-repo.git?ref=master"
   namespace    = "cp"
   stage        = "prod"
-  name         = "domain.com"
+  name         = "chart-repo"
+  cluster_name = "us-east-1.cloudposse.com"
   nodes_name   = "nodes"
 
   tags = {
-    Cluster = "k8s.domain.com"
+    Cluster = "us-east-1.cloudposse.com"
   }
 }
 ```
@@ -24,15 +25,16 @@ module "kops_chart_repo" {
 
 ## Variables
 
-|  Name              |  Default     |  Description                                                                     | Required |
-|:-------------------|:-------------|:---------------------------------------------------------------------------------|:--------:|
-| `namespace`        | ``           | Namespace (_e.g._ `cp` or `cloudposse`)                                          | Yes      |
-| `stage`            | ``           | Stage (_e.g._ `prod`, `dev`, `staging`)                                          | Yes      |
-| `name`             | ``           | Name of the Kops DNS zone (_e.g._ `domain.com`)                                  | Yes      |
-| `attributes`       | `[]`         | Additional attributes (_e.g._ `policy` or `role`)                                | No       |
-| `tags`             | `{}`         | Additional tags  (_e.g._ `map("BusinessUnit","XYZ")`                             | No       |
-| `delimiter`        | `-`          | Delimiter to be used between `namespace`, `stage`, `name`, and `attributes`      | No       |
-| `nodes_name`       | `nodes`      | k8s nodes subdomain name in the Kops DNS zone                                    | No       |
+|  Name              |  Default        |  Description                                                                     | Required |
+|:-------------------|:----------------|:---------------------------------------------------------------------------------|:--------:|
+| `namespace`        | ``              | Namespace (_e.g._ `cp` or `cloudposse`)                                          | Yes      |
+| `stage`            | ``              | Stage (_e.g._ `prod`, `dev`, `staging`)                                          | Yes      |
+| `cluster_name`     | ``              | Cluster name (_e.g._ `us-east-1.cloudposse.com`)                                 | Yes      |
+| `name`             | `chart-repo`    | Name (_e.g._ `chart-repo`)                                                       | No       |
+| `attributes`       | `[]`            | Additional attributes (_e.g._ `1`)                                               | No       |
+| `tags`             | `{}`            | Additional tags  (_e.g._ `map("Cluster","us-east-1.cloudposse.com")`             | No       |
+| `delimiter`        | `-`             | Delimiter to be used between `namespace`, `stage`, `name` and `attributes`       | No       |
+| `nodes_name`       | `nodes`         | Kops nodes subdomain name in the cluster DNS zone                                | No       |
 
 
 ## Outputs

--- a/main.tf
+++ b/main.tf
@@ -10,7 +10,7 @@ module "label" {
 
 module "kops_metadata" {
   source     = "git::https://github.com/cloudposse/terraform-aws-kops-metadata.git?ref=tags/0.1.1"
-  dns_zone   = "${var.name}"
+  dns_zone   = "${var.cluster_name}"
   nodes_name = "${var.nodes_name}"
 }
 
@@ -54,7 +54,7 @@ data "aws_iam_policy_document" "default" {
 resource "aws_iam_policy" "default" {
   name        = "${module.label.id}"
   policy      = "${data.aws_iam_policy_document.default.json}"
-  description = "Allow k8s nodes to get/put/delete objects from the chart repo S3 bucket"
+  description = "Allow Kops nodes to get/put/delete objects from the chart repo S3 bucket"
 }
 
 data "aws_iam_policy_document" "role_trust" {
@@ -83,7 +83,7 @@ data "aws_iam_policy_document" "role_trust" {
 resource "aws_iam_role" "default" {
   name               = "${module.label.id}"
   assume_role_policy = "${data.aws_iam_policy_document.role_trust.json}"
-  description        = "Allow k8s nodes to get/put/delete objects from the chart repo S3 bucket"
+  description        = "Allow Kops nodes to get/put/delete objects from the chart repo S3 bucket"
 }
 
 resource "aws_iam_role_policy_attachment" "default" {

--- a/variables.tf
+++ b/variables.tf
@@ -10,29 +10,35 @@ variable "stage" {
 
 variable "name" {
   type        = "string"
-  description = "Name of the Kops DNS zone (e.g. `domain.com`)"
+  default     = "chart-repo"
+  description = "Name (e.g. `chart-repo`)"
 }
 
 variable "delimiter" {
   type        = "string"
   default     = "-"
-  description = "Delimiter to be used between `namespace`, `stage`, `name`, and `attributes`"
+  description = "Delimiter to be used between `namespace`, `stage`, `name` and `attributes`"
 }
 
 variable "attributes" {
   type        = "list"
   default     = []
-  description = "Additional attributes (e.g. `policy` or `role`)"
+  description = "Additional attributes (e.g. `1`)"
 }
 
 variable "tags" {
   type        = "map"
   default     = {}
-  description = "Additional tags (e.g. map('BusinessUnit`,`XYZ`)"
+  description = "Additional tags (e.g. map(`BusinessUnit`,`XYZ`)"
+}
+
+variable "cluster_name" {
+  type        = "string"
+  description = "Kops cluster name (e.g. `us-east-1.cloudposse.com` or `cluster-1.cloudposse.com`)"
 }
 
 variable "nodes_name" {
   type        = "string"
   default     = "nodes"
-  description = "k8s nodes subdomain name in the Kops DNS zone"
+  description = "Kops nodes subdomain name in the cluster DNS zone"
 }


### PR DESCRIPTION
## what
* Separate `cluster_name` and `name` variables

## why
* Use `name` variable for all created resources (S3 buckets, IAM Roles, etc.)
* Use `cluster_name` as a pattern to lookup Kops clusters
