### PR TITLE
Permit Masters to Assume Role

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -74,6 +74,7 @@ data "aws_iam_policy_document" "role_trust" {
       type = "AWS"
 
       identifiers = [
+        "${module.kops_metadata.masters_role_arn}",
         "${module.kops_metadata.nodes_role_arn}",
       ]
     }

--- a/variables.tf
+++ b/variables.tf
@@ -35,7 +35,7 @@ variable "tags" {
 variable "permitted_nodes" {
   type        = "string"
   description = "Kops kubernetes nodes that are permitted to assume the role (e.g. 'nodes', 'masters', or 'both')"
-  value       = "both"
+  default     = "both"
 }
 
 variable "cluster_name" {

--- a/variables.tf
+++ b/variables.tf
@@ -32,9 +32,21 @@ variable "tags" {
   description = "Additional tags (e.g. map(`BusinessUnit`,`XYZ`)"
 }
 
+variable "permitted_nodes" {
+  type        = "string"
+  description = "Kops kubernetes nodes that are permitted to assume the role (e.g. 'nodes', 'masters', or 'both')"
+  value       = "both"
+}
+
 variable "cluster_name" {
   type        = "string"
   description = "Kops cluster name (e.g. `us-east-1.cloudposse.com` or `cluster-1.cloudposse.com`)"
+}
+
+variable "masters_name" {
+  type        = "string"
+  default     = "masters"
+  description = "Kops masters subdomain name in the cluster DNS zone"
 }
 
 variable "nodes_name" {


### PR DESCRIPTION
## what
* Grant masters, nodes or both the permission to assume role

## why
* `kube2iam` expects workers to be able to assume role
* `kiam` expects masters only to assume role (https://github.com/cloudposse/geodesic/pull/165)