### PR TITLE
Add a required variable

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -16,6 +16,7 @@ module "kops_metadata" {
 }
 
 resource "aws_s3_bucket" "default" {
+  count         = "${var.required }"
   bucket        = "${module.label.id}"
   acl           = "private"
   force_destroy = false


### PR DESCRIPTION
Since we are not required to create a separate chart repository in each account. Leaving it up to team's configuration. Several teams want to reuse the same charts, atleast infra charts.