### PR TITLE
Switch from terraform-aws-kops-metadata to terraform-aws-kops-data-iam

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,6 @@ Available targets:
   lint                                Lint terraform code
 
 ```
-
 ## Inputs
 
 | Name | Description | Type | Default | Required |
@@ -191,7 +190,7 @@ In general, PRs are welcome. We follow the typical "fork-and-pull" Git workflow.
 
 ## Copyright
 
-Copyright © 2017-2018 [Cloud Posse, LLC](https://cpco.io/copyright)
+Copyright © 2017-2019 [Cloud Posse, LLC](https://cpco.io/copyright)
 
 
 

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -1,4 +1,3 @@
-
 ## Inputs
 
 | Name | Description | Type | Default | Required |

--- a/main.tf
+++ b/main.tf
@@ -9,10 +9,8 @@ module "label" {
 }
 
 module "kops_metadata" {
-  source       = "git::https://github.com/cloudposse/terraform-aws-kops-metadata.git?ref=tags/0.1.1"
-  dns_zone     = "${var.cluster_name}"
-  nodes_name   = "${var.nodes_name}"
-  masters_name = "${var.masters_name}"
+  source       = "git::https://github.com/cloudposse/terraform-aws-kops-data-iam.git?ref=tags/0.1.0"
+  cluster_name = "${var.cluster_name}"
 }
 
 resource "aws_s3_bucket" "default" {


### PR DESCRIPTION
## what
Switch from using https://github.com/cloudposse/terraform-aws-kops-metadata to https://github.com/cloudposse/terraform-aws-kops-data-iam
## why
Fixes failure of previous version when kops VPC ID cannot be found